### PR TITLE
Fix #5: system cannot find the file specified

### DIFF
--- a/pybundlr/pybundlr.py
+++ b/pybundlr/pybundlr.py
@@ -155,7 +155,7 @@ def _run_cmd(cmd:str):
     cmd = _remove_0x_in_key(cmd)
     print(f"\nRUN COMMAND: {_safe_print(cmd)}")
     args = cmd.split(" ")
-    completed_process = subprocess.run(args, capture_output=True, check=True)
+    completed_process = subprocess.run(args, capture_output=True, check=True, shell=True)
 
     stdout = completed_process.stdout.decode("ascii")
     stderr = completed_process.stderr.decode("ascii")


### PR DESCRIPTION
Fixes #5.

Changes proposed in this PR:

- The file specified that cannot be found is not the one provided in the url, it's the 'bundlr' binary
- bundlr is not found because subprocess in python is not executed inside the shell by default
- shell=True makes python execute the subprocess inside the shell, where it can find the binaries