### PR TITLE
Fixes Try Except with the correct error

### DIFF
--- a/pybundlr/pybundlr.py
+++ b/pybundlr/pybundlr.py
@@ -160,7 +160,7 @@ def _run_cmd(cmd:str):
     try:
         shell = False
         completed_process = subprocess.run(args, capture_output=True, check=True, shell=shell)
-    except subprocess.CalledProcessError:
+    except FileNotFoundError:
         shell = True
         completed_process = subprocess.run(args, capture_output=True, check=True, shell=shell)
         


### PR DESCRIPTION
Changes proposed in this PR:

- The try catch reintroduced the "file not found error" bug because of the error type
- The process is not failing, it is executing correctly. It cannot find the executable unless it is executed inside a shell
- This PR replaces the error "subprocess.CalledProcessError" with "FileNotFoundError" to make the try / except work