### PR TITLE
small change to make it compatible with web3>=6.0.0

### DIFF
--- a/pybundlr/pybundlr.py
+++ b/pybundlr/pybundlr.py
@@ -200,7 +200,7 @@ def _safe_print(cmd: str) -> str:
 #eth convenience functions
 
 def eth_address(eth_private_key:str) -> str:
-    account = web3.eth.Account.from_key(eth_private_key)
+    account = web3.Account.from_key(eth_private_key)
     return account.address
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 enforce-typing==1.0.0.post1
 pytest
 requests>=2.21.0
-web3>=5.28.0
+web3>=6.0.0
 


### PR DESCRIPTION
Fixes #23

Changes proposed in this PR:

- web3>=6.0.0 does not use web.eth.Account, instead it uses web3.Account directly
- update to the requirements.txt to make it compatible with web3>=6.0.0
- 